### PR TITLE
Load autojump

### DIFF
--- a/configs/.shellrc
+++ b/configs/.shellrc
@@ -22,3 +22,9 @@ fi
 if [ -x "$(command -v arkade)" ]; then
 	source <(arkade completion "${shell}")
 fi
+
+# autojump depends on XDG env vars
+oldstate=$(set +o | grep nounset)
+set +o nounset
+. /usr/share/autojump/autojump.sh
+eval "${oldstate}"


### PR DESCRIPTION
Resolves #3

Since autojump depnds on XDG env vars, turn off `nounset` option and
then restore it afterwards.
