### PR TITLE
Bump Gnome Extensions and always install ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Ok I had enough of installing all my tools, and configurations getting lost
 So.. why not to have a git repo? :)
 
 
+## Notes
+
+- Must restart GNOME (`ALT + F2`) for the GNOME extensions to take place.
+- Must restart the user session (log out and log in) for `ZSH` to run.
+
 ## Test
 
 I use [nektos/act](https://github.com/nektos/act) tool to run the Git Hub Action locally


### PR DESCRIPTION
- Bump GNOME ext: "Primary Input On LockScreen" to v3.
- Bump GNOME ext: "Workspace Matrix" to v35.
- Supports upgrading GNOME extensions when an older version exists.
- Run VIM plugins installation in `nocompatible` mode to avoid plugins errors.
- Always install `ZSH` and run oh-my-zsh in unattended mode (to avoid
  user interaction).
